### PR TITLE
Example multiple primary keys

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -543,5 +543,8 @@
          "example":""
       }
    ],
-   "primaryKey":"id"
+   "primaryKey":[
+      "id",
+      "labels_autre"
+   ]
 }


### PR DESCRIPTION
Exemple de deux champs servant de clés primaires.